### PR TITLE
Add --version flag to xcrs and document cargo install

### DIFF
--- a/crates/xcrs/src/main.rs
+++ b/crates/xcrs/src/main.rs
@@ -5,6 +5,7 @@ use xcrs::{IosAppTest, XcodeCommandLineTools};
 
 #[derive(Debug, Parser)]
 #[command(name = "xcrs")]
+#[command(version)]
 #[command(about = "Cross-platform mobile and TV app automation")]
 struct Cli {
     /// Run as a standalone Model Context Protocol server over stdio.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -259,6 +259,12 @@ smb --mcp --scope automation
 xcrs --mcp
 ```
 
+> **Installing `xcrs`:** the standalone binary is published to
+> [crates.io](https://crates.io/crates/xcrs) — install it with
+> `cargo install xcrs`. It is **not** distributed through Homebrew; `brew
+> install smbcloud-cli` only provides the `smb` binary (use `smb --mcp --scope
+> automation` for the same tools without a separate install).
+
 Both commands expose the same target-aware tools with the same names. Tool
 names do not repeat the server brand because MCP clients already namespace
 them by server.


### PR DESCRIPTION
## What

Two small fixes for the standalone `xcrs` CLI, discovered while debugging why a Homebrew `smb` install didn't surface the xcrs automation tools.

**A. `xcrs --version` flag** — `xcrs` previously had no `--version`; running it errored with "unexpected argument". Added `#[command(version)]` to the clap `Cli` struct so `xcrs --version` / `xcrs -V` report the crate version, matching `smb` and the version recorded in the MCP registry (`server-xcrs.json`).

```
$ xcrs --version
xcrs 0.5.0
```

**B. Install docs** — documented in `docs/mcp.md` that `xcrs` is installed via `cargo install xcrs` (crates.io), **not** Homebrew. `brew install smbcloud-cli` ships only the `smb` binary; `smb --mcp --scope automation` exposes the same automation tools without a separate install.

## Why

The `--version` gap is also a prerequisite for the planned NuGet distribution of `xcrs` (its smoke test runs `xcrs --version`). The docs note prevents the "I installed it via Homebrew but xcrs is missing" confusion.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --package xcrs --tests -- -D warnings` — clean
- Release build + `xcrs --version` / `xcrs -V` confirmed

Release Notes:

- Added a `--version` flag to the `xcrs` CLI.
