### PR TITLE
Fix mail app id data type parsing

### DIFF
--- a/crates/cli/src/cloud-mail/render.rs
+++ b/crates/cli/src/cloud-mail/render.rs
@@ -41,7 +41,7 @@ pub(crate) fn print_mail_apps(mail_apps: &[MailApp]) {
 
     for mail_app in mail_apps {
         println!(
-            "#{} {} ({}) [{}] project={} inboxes={}",
+            "{} {} ({}) [{}] project={} inboxes={}",
             mail_app.id,
             style(&mail_app.name).bold(),
             mail_app.domain,
@@ -54,7 +54,7 @@ pub(crate) fn print_mail_apps(mail_apps: &[MailApp]) {
 
 pub(crate) fn print_mail_app_detail(mail_app: &MailApp) {
     print_heading("Mail app");
-    print_field("ID", mail_app.id.to_string());
+    print_field("ID", &mail_app.id);
     print_field("Name", &mail_app.name);
     print_field("Domain", &mail_app.domain);
     print_field("Status", mail_app.status.to_string());
@@ -76,7 +76,7 @@ pub(crate) fn print_mail_app_detail(mail_app: &MailApp) {
 
     for inbox in &mail_app.inboxes {
         println!(
-            "#{} {} -> {} [{}]",
+            "{} {} -> {} [{}]",
             inbox.id,
             style(&inbox.full_address).bold(),
             inbox.forward_to_email,
@@ -87,8 +87,8 @@ pub(crate) fn print_mail_app_detail(mail_app: &MailApp) {
 
 pub(crate) fn print_mail_inbox_detail(mail_inbox: &MailInbox) {
     print_heading("Mail inbox");
-    print_field("ID", mail_inbox.id.to_string());
-    print_field("Mail app ID", mail_inbox.mail_app_id.to_string());
+    print_field("ID", &mail_inbox.id);
+    print_field("Mail app ID", &mail_inbox.mail_app_id);
     print_field("Project ID", mail_inbox.project_id.to_string());
     print_field("Tenant ID", mail_inbox.tenant_id.to_string());
     print_field("Local part", &mail_inbox.local_part);
@@ -139,7 +139,7 @@ pub(crate) fn print_mail_messages(messages: &[MailMessage]) {
 
     for message in messages {
         println!(
-            "#{} {} from {} [{}]",
+            "{} {} from {} [{}]",
             message.id,
             message
                 .subject
@@ -156,8 +156,8 @@ pub(crate) fn print_mail_messages(messages: &[MailMessage]) {
 
 pub(crate) fn print_mail_message_detail(message: &MailMessage) {
     print_heading("Mail message");
-    print_field("ID", message.id.to_string());
-    print_field("Inbox ID", message.mail_inbox_id.to_string());
+    print_field("ID", &message.id);
+    print_field("Inbox ID", &message.mail_inbox_id);
     print_field("Status", message.status.to_string());
     print_field("Provider message ID", &message.provider_message_id);
     print_field("Original recipient", &message.original_recipient_email);

--- a/crates/smbcloud-model/src/mail.rs
+++ b/crates/smbcloud-model/src/mail.rs
@@ -45,7 +45,12 @@ impl Display for MailMessageStatus {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MailApp {
-    pub id: i32,
+    // UUIDs, not sequence numbers. The API moved mail_apps, mail_inboxes and
+    // mail_messages onto UUID primary keys; leaving these as i32 made every
+    // `smb mail *` command and every mail MCP tool fail to deserialize with
+    // "invalid type: string ..., expected i32". tenant_id and project_id are
+    // still integers.
+    pub id: String,
     pub name: String,
     pub domain: String,
     pub aws_region: String,
@@ -65,13 +70,13 @@ pub struct MailApp {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MailInbox {
-    pub id: i32,
+    pub id: String,
     pub local_part: String,
     pub full_address: String,
     pub inbox_email: String,
     pub sender_email: String,
     pub forward_to_email: String,
-    pub mail_app_id: i32,
+    pub mail_app_id: String,
     pub project_id: i32,
     pub tenant_id: i32,
     pub last_test_email_sent_at: Option<DateTime<Utc>>,
@@ -85,8 +90,8 @@ pub struct MailInbox {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MailMessage {
-    pub id: i32,
-    pub mail_inbox_id: i32,
+    pub id: String,
+    pub mail_inbox_id: String,
     pub provider_message_id: String,
     pub original_recipient_email: String,
     pub from_email: String,


### PR DESCRIPTION
## Related Issue

Fixes # <!-- issue number, or remove this line if not applicable -->

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] CI / tooling change

## How Has This Been Tested?

<!-- Describe the tests you ran or why tests are not applicable -->

- [x] `cargo test --all-features`
- [x] Manual testing (`smb <command>`)

## Checklist

- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace --tests -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] No new `unwrap()` or `expect()` calls in production code
- [ ] No new `mod.rs` files introduced
- [ ] New dependencies added to root `Cargo.toml` and inherited with `{ workspace = true }`
- [x] Error messages are user-friendly and surfaced to the terminal

## Release Notes

<!-- One bullet. Use "- Added ...", "- Fixed ...", or "- Improved ..." for user-facing changes. Use "- N/A" otherwise. -->

- Fixed MailApp id data type missmatch 
